### PR TITLE
Add github action for generating packaged builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: 'publish'
+on: push
+
+jobs:
+  publish-tauri:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [macos-latest, ubuntu-22.04, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf javascriptcoregtk-4.1 libsoup-3.0-dev
+      - name: update tauri-cli
+        run: |
+          cargo install tauri-cli --debug --git https://github.com/tauri-apps/tauri
+      - name: install frontend dependencies
+        run: npm install
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: bluescribe-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
+          releaseName: 'BlueScribe v__VERSION__'
+          releaseBody: 'See the assets to download this version and install.'
+          releaseDraft: true
+          prerelease: false
+          tauriScript: cargo tauri

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,9 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: install frontend dependencies
-        run: npm install
+        run: npm ci
       - name: Build Web Deployment
         if: matrix.platform == 'ubuntu-22.04'
         run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: 'publish'
-on: push
+
+on:
+  release:
+    types: [released]
 
 jobs:
   publish-tauri:
@@ -17,6 +20,23 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+      - name: install frontend dependencies
+        run: npm install
+      - name: Build Web Deployment
+        if: matrix.platform == 'ubuntu-22.04'
+        run: npm run build
+      - name: Deploy Github Pages (ubuntu only)
+        if: matrix.platform == 'ubuntu-22.04'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/
+      - name: get version (ubuntu/mac)
+        if: matrix.platform != 'windows-latest'
+        run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+      - name: get version (windows only)
+        if: matrix.platform == 'windows-latest'
+        run: echo "PACKAGE_VERSION=$(node -p "require('.\\package.json').version")" >> $env:GITHUB_ENV
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
       - name: install dependencies (ubuntu only)
@@ -27,15 +47,60 @@ jobs:
       - name: update tauri-cli
         run: |
           cargo install tauri-cli --debug --git https://github.com/tauri-apps/tauri
-      - name: install frontend dependencies
-        run: npm install
-      - uses: tauri-apps/tauri-action@v0
+      - name: build tauri
+        id: tauri
+        uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: bluescribe-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
-          releaseName: 'BlueScribe v__VERSION__'
-          releaseBody: 'See the assets to download this version and install.'
-          releaseDraft: true
-          prerelease: false
+          releaseId: ${{ github.event.release.id }}
           tauriScript: cargo tauri
+          args: '--config ''{"package": {"version": "${{env.PACKAGE_VERSION}}"}}'''
+      - name: portable build (ubuntu only)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          PORTABLE_PACKAGE=bluescribe-v${{env.PACKAGE_VERSION}}-portable-linux-x64
+          echo "PORTABLE_PACKAGE=$PORTABLE_PACKAGE" >> $GITHUB_ENV
+          mkdir -p dist/$PORTABLE_PACKAGE
+          cp README.md LICENSE dist/$PORTABLE_PACKAGE
+          cp src-tauri/target/release/bluescribe dist/$PORTABLE_PACKAGE
+          cd dist
+          tar -czvf $PORTABLE_PACKAGE.tar.gz $PORTABLE_PACKAGE
+          cd ..
+      - name: upload portable build (ubuntu only)
+        if: matrix.platform == 'ubuntu-22.04'
+        uses: shogo82148/actions-upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/${{env.PORTABLE_PACKAGE}}.tar.gz
+          asset_name: ${{env.PORTABLE_PACKAGE}}.tar.gz
+          asset_content_type: application/gzip
+      - name: portable build (windows only)
+        if: matrix.platform == 'windows-latest'
+        run: |
+          $PORTABLE_PACKAGE="bluescribe-v${{env.PACKAGE_VERSION}}-portable-win-x64"
+          echo "PORTABLE_PACKAGE=$PORTABLE_PACKAGE" >> $env:GITHUB_ENV
+          mkdir -p dist/$PORTABLE_PACKAGE
+          cp README.md dist/$PORTABLE_PACKAGE
+          cp LICENSE dist/$PORTABLE_PACKAGE
+          cp src-tauri/target/release/bluescribe.exe dist/$PORTABLE_PACKAGE
+      - name: portable zip (windows only)
+        if: matrix.platform == 'windows-latest'
+        uses: thedoctor0/zip-release@0.7.1
+        with:
+          type: zip
+          filename: ${{env.PORTABLE_PACKAGE}}.zip
+          directory: dist
+          path: ${{env.PORTABLE_PACKAGE}}
+      - name: upload portable build (windows only)
+        if: matrix.platform == 'windows-latest'
+        uses: shogo82148/actions-upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/${{env.PORTABLE_PACKAGE}}.zip
+          asset_name: ${{env.PORTABLE_PACKAGE}}.zip
+          asset_content_type: application/zip

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,8 +7,7 @@
     "distDir": "../build"
   },
   "package": {
-    "productName": "bluescribe",
-    "version": "0.1.0"
+    "productName": "bluescribe"
   },
   "tauri": {
     "bundle": {


### PR DESCRIPTION
Starting this early for discussion. This isn't where I'd check it in yet since:
- [x] Right now it does the build on any push to any branch for ease of getting things together in the first place
- [x] Version numbers don't match up since they pull from the rust package version
- [x] I would like a portable .zip version of the binary output since personally I hate installers :)
- [x] Rename the action from a generic "publish" so it's clear it's not handling the ghpages deploy

That first point is the one I'd like feedback on. In the past, I feel like in the past, my personal preference has been to set actions like this so they trigger on release create ala
```yml
on:
  release:
    types: [created]
```

Did you have any workflow in mind that you want this action to match up to?

Example packages for windows/linux/mac are available here: https://github.com/PretzelVector/bluescribe/releases/tag/bluescribe-v0.1.0