### PR TITLE
Map text data into `#text`

### DIFF
--- a/src-tauri/src/read_files.rs
+++ b/src-tauri/src/read_files.rs
@@ -38,7 +38,10 @@ fn read_xml(path: &Path) -> Result<Value, String> {
     }
 
     let xml_data = xml_data.unwrap();
-    let json_builder = JsonConfig::new().merge_attrs(true).finalize();
+    let json_builder = JsonConfig::new()
+        .merge_attrs(true)
+        .charkey("#text")
+        .finalize();
     let json = json_builder.build_from_xml(&xml_data);
 
     if json.is_err() {


### PR DESCRIPTION
Fixes bug in https://github.com/BlueWinds/bluescribe/pull/19#issuecomment-1626367538

![image](https://github.com/BlueWinds/bluescribe/assets/95664360/b21a7f2f-09e3-4be5-9bd5-3c48a98437a0)
