### PR TITLE
Add Testing to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: 'test'
+
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  test:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -10,7 +10,7 @@ describe('40k', () => {
   let gameData
   beforeAll(async () => {
     gameData = await readFiles(path.join(__dirname, 'downloadedGameSystems/wh40k'), fs)
-  })
+  }, 60000)
 
   const rosters = {
     '12AvatarKhaine.ros': {


### PR DESCRIPTION
Runs `npm test` on push and pull request.

Currently, this fails for a the single test visible [here](https://github.com/BlueWinds/bluescribe/actions/runs/5697073578/job/15443222321?pr=27#step:6:29). I'm assuming this isn't as easy as fixing the gold comparison, so might need to wait before being merged.

Edit: Link to failure in test run below rather than an earlier test run.