### PR TITLE
Fix XML export bug

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -37,7 +37,7 @@ describe('40k', () => {
     'Chaos-Aeldari-CategoryConstraints.ros': {
       '': [
         'Roster has 559pts, more than the limit of 5pts',
-        'Roster has 32 PL, more than the limit of 5 PL',
+        'Roster has 32PL, more than the limit of 5PL',
         'Roster has 10CP, more than the limit of 5CP',
       ],
       'forces.force.0': [

--- a/src/repo/index.js
+++ b/src/repo/index.js
@@ -56,7 +56,7 @@ export const xmlData = async (contents, filename = '') => {
 
   // Working around bug in fast-xml-parser
   // https://github.com/NaturalIntelligence/fast-xml-parser/issues/590
-  data = data.replace(/#text="(.+?)"(.*?)>/g, '$2>$1')
+  data = data.replace(/#text="(.+?)"(.*?)>/gs, '$2>$1')
 
   if (filename.endsWith('z')) {
     const zipFileWriter = new BlobWriter()


### PR DESCRIPTION
Uses flag `s` to make sure the xml-fast parse fix takes into account `\n`
Fixes #32 